### PR TITLE
Use sbt_version as set in g8 properties

### DIFF
--- a/src/main/g8/project/build.properties
+++ b/src/main/g8/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.3
+sbt.version=$sbt_version$


### PR DESCRIPTION
This PR just sets the `sbt.version` in `project/build.properties` to use g8 template value.